### PR TITLE
added support to copy more files from the previous calculation in

### DIFF
--- a/atomate/vasp/fireworks/core.py
+++ b/atomate/vasp/fireworks/core.py
@@ -308,6 +308,7 @@ class StaticFW(Firework):
         vasptodb_kwargs=None,
         parents=None,
         spec_structure_key=None,
+        additional_files_from_prev_calc=[],
         **kwargs,
     ):
         """
@@ -355,12 +356,15 @@ class StaticFW(Firework):
                 )
             )
         elif prev_calc_dir:
-            t.append(CopyVaspOutputs(calc_dir=prev_calc_dir, contcar_to_poscar=True))
+            t.append(
+                CopyVaspOutputs(calc_dir=prev_calc_dir, contcar_to_poscar=True,
+                                additional_files=additional_files_from_prev_calc))
             t.append(WriteVaspStaticFromPrev(other_params=vasp_input_set_params))
         elif parents:
             if prev_calc_loc:
                 t.append(
-                    CopyVaspOutputs(calc_loc=prev_calc_loc, contcar_to_poscar=True)
+                    CopyVaspOutputs(calc_loc=prev_calc_loc, contcar_to_poscar=True,
+                                    additional_files=additional_files_from_prev_calc)
                 )
             t.append(WriteVaspStaticFromPrev(other_params=vasp_input_set_params))
         elif structure:


### PR DESCRIPTION
StaticFW.

## Summary

Can now copy additional files from the previous calculation if the `StaticFW` has a parent and `prev_calc_loc` or `prev_calc_dir` is set. See[ this post](https://matsci.org/t/option-to-copy-chgcar-or-wavecar-from-prev-calc-loc-or-prev-calc-dir-in-staticfw/38450) for details.
